### PR TITLE
axum-tracing-opentelemetry requires, at least, rust 1.70 to compile.

### DIFF
--- a/axum-tracing-opentelemetry/Cargo.toml
+++ b/axum-tracing-opentelemetry/Cargo.toml
@@ -9,6 +9,7 @@ categories = [
   "web-programming",
 ]
 homepage = "https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/axum-tracing-opentelemetry"
+rust-version = "1.70"
 edition.workspace = true
 version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Make it explicit that rust 1.70 is required
On older versions we might have this kind of compile error.

```
error: implementation of `std::fmt::Debug` is not general enough                                                                                                                                                                                                                                                                                                                         
   --> axum-tracing-opentelemetry/src/middleware/trace_extractor.rs:68:5                                                                                                                                                                                                                                                                                                                  
    |                                                                                                                                                                                                                                                                                                                                                                                     
 66 | #[derive(Default, Debug, Clone)]                                                                                                                                                                                                                                                                                                                                                    
    |                   ----- in this derive macro expansion                                                                                                                                                                                                                                                                                                                              
 67 | pub struct OtelAxumLayer {                                                                                                                                                                                                                                                                                                                                                          
 68 |     filter: Option<Filter>,                                                                                                                                                                                                                                                                                                                                                         
    |     ^^^^^^^^^^^^^^^^^^^^^^ implementation of `std::fmt::Debug` is not general enough                                                                                                                                                                                                                                                                                                
    |                                                                                                                                                                                                                                                                                                                                                                                     
     = note: `std::fmt::Debug` would have to be implemented for the type `for<'a> fn(&'a str) -> bool`                                                                                                                                                                                                                                                                                     
     = note: ...but `std::fmt::Debug` is actually implemented for the type `fn(&'0 str) -> bool`, for some specific lifetime `'0`                                                                                                                                                                                                                                                          
     = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)                                                                                                                                                                                                                                                              
```