### PR TITLE
feat: add span.type=web on spans

### DIFF
--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__call_with_w3c_trace.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__call_with_w3c_trace.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /users/123
     url.scheme: ""
     user_agent.original: ""
@@ -32,6 +33,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: "GET /users/:id"
     server.address: ""
+    span.type: web
     url.path: /users/123
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__call_with_w3c_trace_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__call_with_w3c_trace_otel_spans.snap
@@ -23,6 +23,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_6\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/users/123\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__empty_http_route_for_nonexisting_route.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__empty_http_route_for_nonexisting_route.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /idontexist/123
     url.scheme: ""
     user_agent.original: ""
@@ -32,6 +33,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /idontexist/123
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__empty_http_route_for_nonexisting_route_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__empty_http_route_for_nonexisting_route_otel_spans.snap
@@ -23,6 +23,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_2\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/idontexist/123\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__extract_route_from_nested.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__extract_route_from_nested.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /nest/123
     url.scheme: ""
     user_agent.original: ""
@@ -32,6 +33,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: "GET /nest/:nest_id"
     server.address: ""
+    span.type: web
     url.path: /nest/123
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__extract_route_from_nested_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__extract_route_from_nested_otel_spans.snap
@@ -21,6 +21,7 @@ expression: otel_spans
     idle_ns: ignore
     network.protocol.version: "Some(AnyValue { value: Some(StringValue(\"1.1\")) })"
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
+    span.type: "Some(AnyValue { value: Some(StringValue(\"web\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_9\")) })"
     url.path: "Some(AnyValue { value: Some(StringValue(\"/nest/123\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_headers.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_headers.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /users/123
     url.scheme: ""
     user_agent.original: tests
@@ -32,6 +33,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: "GET /users/:id"
     server.address: ""
+    span.type: web
     url.path: /users/123
     url.scheme: ""
     user_agent.original: tests

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_headers_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_headers_otel_spans.snap
@@ -23,6 +23,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_5\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/users/123\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"tests\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_route_for_existing_route.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_route_for_existing_route.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: example.com
+    span.type: web
     url.path: /users/123
     url.scheme: http
     user_agent.original: ""
@@ -32,6 +33,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: "GET /users/:id"
     server.address: example.com
+    span.type: web
     url.path: /users/123
     url.scheme: http
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_route_for_existing_route_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__filled_http_route_for_existing_route_otel_spans.snap
@@ -23,6 +23,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"example.com\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_1\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/users/123\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"http\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_error.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_error.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /status/500
     url.scheme: ""
     user_agent.original: ""
@@ -33,6 +34,7 @@ expression: tracing_events
     otel.name: GET /status/500
     otel.status_code: ERROR
     server.address: ""
+    span.type: web
     url.path: /status/500
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_error_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_error_otel_spans.snap
@@ -23,6 +23,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_4\")) })"
+    span.type: "Some(AnyValue { value: Some(StringValue(\"web\")) })
     url.path: "Some(AnyValue { value: Some(StringValue(\"/status/500\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_ok.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_ok.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /users/123
     url.scheme: ""
     user_agent.original: ""
@@ -32,6 +33,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: "GET /users/:id"
     server.address: ""
+    span.type: web
     url.path: /users/123
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_ok_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__status_code_on_close_for_ok_otel_spans.snap
@@ -23,6 +23,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_3\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/users/123\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /with_child_span
     url.scheme: ""
     user_agent.original: ""
@@ -31,6 +32,7 @@ expression: tracing_events
       otel.kind: Server
       otel.name: GET /with_child_span
       server.address: ""
+      span.type: web
       url.path: /with_child_span
       url.scheme: ""
       user_agent.original: ""
@@ -51,6 +53,7 @@ expression: tracing_events
       otel.kind: Server
       otel.name: GET /with_child_span
       server.address: ""
+      span.type: web
       url.path: /with_child_span
       url.scheme: ""
       user_agent.original: ""
@@ -70,6 +73,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET /with_child_span
     server.address: ""
+    span.type: web
     url.path: /with_child_span
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote.snap
@@ -12,6 +12,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET
     server.address: ""
+    span.type: web
     url.path: /with_child_span
     url.scheme: ""
     user_agent.original: ""
@@ -31,6 +32,7 @@ expression: tracing_events
       otel.kind: Server
       otel.name: GET /with_child_span
       server.address: ""
+      span.type: web
       url.path: /with_child_span
       url.scheme: ""
       user_agent.original: ""
@@ -51,6 +53,7 @@ expression: tracing_events
       otel.kind: Server
       otel.name: GET /with_child_span
       server.address: ""
+      span.type: web
       url.path: /with_child_span
       url.scheme: ""
       user_agent.original: ""
@@ -70,6 +73,7 @@ expression: tracing_events
     otel.kind: Server
     otel.name: GET /with_child_span
     server.address: ""
+    span.type: web
     url.path: /with_child_span
     url.scheme: ""
     user_agent.original: ""

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote_otel_spans.snap
@@ -47,6 +47,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_8\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/with_child_span\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_otel_spans.snap
@@ -47,6 +47,7 @@ expression: otel_spans
     server.address: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     thread.id: ignore
     thread.name: "Some(AnyValue { value: Some(StringValue(\"middleware::trace_extractor::tests::check_span_event::case_7\")) })"
+    span.type: web
     url.path: "Some(AnyValue { value: Some(StringValue(\"/with_child_span\")) })"
     url.scheme: "Some(AnyValue { value: Some(StringValue(\"\")) })"
     user_agent.original: "Some(AnyValue { value: Some(StringValue(\"\")) })"

--- a/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use crate::http::{http_flavor, http_host, http_method, url_scheme, user_agent};
+use crate::span_type::SpanType;
 use crate::TRACING_TARGET;
 use tracing::field::Empty;
 
@@ -29,7 +30,7 @@ pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
         trace_id = Empty, // to set on response
         request_id = Empty, // to set
         exception.message = Empty, // to set on response
-        "span.type" = "web",
+        "span.type" = SpanType::Web.to_string(), // non-official open-telemetry key, only supported by Datadog
     )
 }
 

--- a/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
@@ -29,6 +29,7 @@ pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
         trace_id = Empty, // to set on response
         request_id = Empty, // to set
         exception.message = Empty, // to set on response
+        "span.type" = "web",
     )
 }
 

--- a/tracing-opentelemetry-instrumentation-sdk/src/lib.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/lib.rs
@@ -7,6 +7,7 @@
 
 #[cfg(feature = "http")]
 pub mod http;
+mod span_type;
 
 use opentelemetry_api::Context;
 

--- a/tracing-opentelemetry-instrumentation-sdk/src/span_type.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/span_type.rs
@@ -1,0 +1,41 @@
+// SpanType is a non official open-telemetry key, only supported by Datadog, to help categorize traces.
+// Documentation: https://github.com/open-telemetry/opentelemetry-rust/blob/ccb510fbd6fdef9694e3b751fd01dbe33c7345c0/opentelemetry-datadog/src/lib.rs#L29-L30
+// Usage: It should be informed as span.type span key
+// Reference: https://github.com/DataDog/dd-trace-go/blob/352b090d4f90527d35a8ad535b97689e346589c8/ddtrace/ext/app_types.go#L31-L81
+#[warn(dead_code)]
+pub enum SpanType {
+    Web,
+    Http,
+    Sql,
+    Cassandra,
+    Redis,
+    Memcached,
+    Mongodb,
+    Elasticsearch,
+    Leveldb,
+    Dns,
+    Queue,
+    Consul,
+    Graphql,
+}
+
+impl ToString for SpanType {
+    fn to_string(&self) -> String {
+        match self {
+            SpanType::Web => "web",
+            SpanType::Http => "http",
+            SpanType::Sql => "sql",
+            SpanType::Cassandra => "cassandra",
+            SpanType::Redis => "redis",
+            SpanType::Memcached => "memcached",
+            SpanType::Mongodb => "mongodb",
+            SpanType::Elasticsearch => "elasticsearch",
+            SpanType::Leveldb => "leveldb",
+            SpanType::Dns => "dns",
+            SpanType::Queue => "queue",
+            SpanType::Consul => "consul",
+            SpanType::Graphql => "graphql",
+        }
+        .to_owned()
+    }
+}


### PR DESCRIPTION
**Issue**
- datadog root http span needs to indicate the `span.type` attribute, as [mentioned here](https://github.com/open-telemetry/opentelemetry-rust/blob/ccb510fbd6fdef9694e3b751fd01dbe33c7345c0/opentelemetry-datadog/src/lib.rs#L29-L30) on the opentelemetry_datadog exporter.
- this influences the way datadog APM present some information, like APDEX, that is not available if this fields is not filled with `web`

**Solution**
- default to always inform `span.type` = `web` on `HTTP request` trace

PS: I can make it optional if needed, or based in some config/env var, just let me know!