### PR TITLE
feat: enable simple basic grpc tls endpoint

### DIFF
--- a/init-tracing-opentelemetry/Cargo.toml
+++ b/init-tracing-opentelemetry/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry-stdout = { version = "0.1", features = [
 opentelemetry-semantic-conventions = { version = "0.12", optional = true }
 opentelemetry-zipkin = { version = "0.18", features = [], optional = true }
 thiserror = "1.0"
-tonic = { version = "0.9", features = ["tls"] }
+tonic = { version = "0.9", optional = true, features = ["tls"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.20"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
@@ -61,9 +61,10 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 
 [features]
 jaeger = ["dep:opentelemetry-jaeger", "tracer"]
-otlp = ["dep:opentelemetry-otlp", "tracer"]
+otlp = ["opentelemetry-otlp/http-proto", "tracer"]
 stdout = ["dep:opentelemetry-stdout", "tracer"]
 tracer = ["dep:opentelemetry-semantic-conventions"]
 xray = ["dep:opentelemetry-aws"]
 zipkin = ["dep:opentelemetry-zipkin"]
 tracing_subscriber_ext = ["dep:tracing-subscriber", "otlp"]
+tls = ["tonic/tls", "opentelemetry-otlp/tls", "opentelemetry-otlp/tls-roots"]

--- a/init-tracing-opentelemetry/Cargo.toml
+++ b/init-tracing-opentelemetry/Cargo.toml
@@ -20,9 +20,7 @@ opentelemetry-aws = { version = "0.8", optional = true }
 opentelemetry-jaeger = { version = "0.19", features = [
   "rt-tokio",
 ], optional = true }
-opentelemetry-otlp = { version = "0.13", optional = true, features = [
-  "http-proto", "tls", "tls-roots",
-] }
+opentelemetry-otlp = { version = "0.13", optional = true }
 opentelemetry-stdout = { version = "0.1", features = [
   "trace",
 ], optional = true }

--- a/init-tracing-opentelemetry/Cargo.toml
+++ b/init-tracing-opentelemetry/Cargo.toml
@@ -21,7 +21,7 @@ opentelemetry-jaeger = { version = "0.19", features = [
   "rt-tokio",
 ], optional = true }
 opentelemetry-otlp = { version = "0.13", optional = true, features = [
-  "http-proto",
+  "http-proto", "tls", "tls-roots",
 ] }
 opentelemetry-stdout = { version = "0.1", features = [
   "trace",
@@ -29,6 +29,7 @@ opentelemetry-stdout = { version = "0.1", features = [
 opentelemetry-semantic-conventions = { version = "0.12", optional = true }
 opentelemetry-zipkin = { version = "0.18", features = [], optional = true }
 thiserror = "1.0"
+tonic = { version = "0.9", features = ["tls"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.20"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/init-tracing-opentelemetry/src/otlp.rs
+++ b/init-tracing-opentelemetry/src/otlp.rs
@@ -138,20 +138,18 @@ mod tests {
     #[case(Some("http/protobuf"), None, "http/protobuf", "http://localhost:4318")] //Devskim: ignore DS137138
     #[case(Some("grpc"), None, "grpc", "http://localhost:4317")] //Devskim: ignore DS137138
     #[case(None, Some("http://localhost:4317"), "grpc", "http://localhost:4317")] //Devskim: ignore DS137138
-    #[cfg_attr(not(feature = "tls"), ignore)]
-    #[case(
+    #[cfg_attr(feature = "tls", case(
         None,
-        Some("https://localhost:4317"), //Devskim: ignore DS137138
+        Some("https://localhost:4317"),
         "grpc/tls",
-        "https://localhost:4317" //Devskim: ignore DS137138
-    )]
-    #[cfg_attr(not(feature = "tls"), ignore)]
-    #[case(
+        "https://localhost:4317"
+    ))]
+    #[cfg_attr(feature = "tls", case(
         Some("grpc/tls"),
-        Some("https://localhost:4317"), //Devskim: ignore DS137138
+        Some("https://localhost:4317"),
         "grpc/tls",
-        "https://localhost:4317" //Devskim: ignore DS137138
-    )]
+        "https://localhost:4317"
+    ))]
     #[case(
         Some("http/protobuf"),
         Some("http://localhost:4318"), //Devskim: ignore DS137138


### PR DESCRIPTION
This is intended to allow the use of a gRPC endpoint with tls.  e.g. `OTEL_EXPORTER_OTLP_ENDPOINT=https://example.org:4317`

It is basic such that it allows for connecting to tls endpoint with a valid CA signed cert, but does not enable client cert authentication or certificate pinning.

I was unable to run the tests.