### PR TITLE
Replace let _ with let _enter

### DIFF
--- a/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
+++ b/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
@@ -136,7 +136,7 @@ where
             tracing::Span::none()
         };
         let future = {
-            let _ = span.enter();
+            let _enter = span.enter();
             self.inner.call(req)
         };
         ResponseFuture {

--- a/tonic-tracing-opentelemetry/src/middleware/client.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/client.rs
@@ -64,7 +64,7 @@ where
         let span = otel_http::grpc_client::make_span_from_request(&req);
         otel_http::inject_context(&find_context_from_tracing(&span), req.headers_mut());
         let future = {
-            let _ = span.enter();
+            let _enter = span.enter();
             self.inner.call(req)
         };
         ResponseFuture {

--- a/tonic-tracing-opentelemetry/src/middleware/server.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/server.rs
@@ -86,7 +86,7 @@ where
             tracing::Span::none()
         };
         let future = {
-            let _ = span.enter();
+            let _enter = span.enter();
             self.inner.call(req)
         };
         ResponseFuture {


### PR DESCRIPTION
See discussion here: https://github.com/rust-lang/rust-clippy/issues/8246

tl;dr: `let _` drops immediately, so for anything that has Guard like behavior, it will not work as expected. `let _enter` will ensure that the guard is dropped at the end of the scope.