### PR TITLE
Fix #126: change level for otel::tracing to info

### DIFF
--- a/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
+++ b/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
@@ -134,6 +134,7 @@ where
         } else {
             tracing::Span::none()
         };
+        eprintln!("span: {:?}.is_disabled{}", span, span.is_disabled());
         let future = {
             let _enter = span.enter();
             self.inner.call(req)

--- a/examples/load/src/main.rs
+++ b/examples/load/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
         for _i in 1..10000 {
-            let _span = tracing::trace_span!(
+            let _span = tracing::info_span!(
                 target: TRACING_TARGET,
                 "Load",
                 http.request.method = "GET",

--- a/init-tracing-opentelemetry/README.md
+++ b/init-tracing-opentelemetry/README.md
@@ -33,7 +33,7 @@ pub fn build_loglevel_filter_layer() -> tracing_subscriber::filter::EnvFilter {
         format!(
             // `otel::tracing` should be a level trace to emit opentelemetry trace & span
             // `otel::setup` set to debug to log detected resources, configuration read and infered
-            "{},otel::tracing=trace,otel=debug",
+            "{},otel::tracing=info,otel=debug",
             std::env::var("RUST_LOG")
                 .or_else(|_| std::env::var("OTEL_LOG_LEVEL"))
                 .unwrap_or_else(|_| "info".to_string())

--- a/init-tracing-opentelemetry/src/tracing_subscriber_ext.rs
+++ b/init-tracing-opentelemetry/src/tracing_subscriber_ext.rs
@@ -41,7 +41,7 @@ pub fn build_loglevel_filter_layer() -> tracing_subscriber::filter::EnvFilter {
         format!(
             // `otel::tracing` should be a level info to emit opentelemetry trace & span
             // `otel::setup` set to debug to log detected resources, configuration read and infered
-            "{},otel::tracing=trace,otel=debug",
+            "{},otel::tracing=info,otel=debug",
             std::env::var("RUST_LOG")
                 .or_else(|_| std::env::var("OTEL_LOG_LEVEL"))
                 .unwrap_or_else(|_| "info".to_string())

--- a/tracing-opentelemetry-instrumentation-sdk/README.md
+++ b/tracing-opentelemetry-instrumentation-sdk/README.md
@@ -35,7 +35,7 @@ The helpers could be used as is or into middleware build on it (eg: [`axum-traci
   - The OpenTelemetry parent Context (and trace_id) is created on `NEW` span or inherited from parent span. The parent context can be overwritten after creation, but until then the `trace_id` is the one from `NEW`, So tracing's log could report none or not-yet set trace_id on event `NEW` and the following until update.
   - To define kind, name,... of OpenTelemetry's span from tracing's span used special record's name: `otel.name`, `otel.kind`, ...
   - Record in a [`tracing`]'s Span should be defined at creation time. So some field are created with value `tracing::field::Empty` to then being updated.
-- Create trace with target `otel::tracing` (and level `trace`), to have a common way to enable / to disable
+- Create trace with target `otel::tracing` (and level `info`), to have a common way to enable / to disable
 
 ## Instrumentations Tips
 
@@ -49,7 +49,7 @@ Use `tracing::instrumented` (no propagation & no update on response)
 fn make_otel_span(db_operation: &str) -> tracing::Span {
     // NO parsing of statement to extract information, not recommended by Specification and time-consuming
     // warning: providing the statement could leek information
-    tracing::trace_span!(
+    tracing::info_span!(
         target: tracing_opentelemetry_instrumentation_sdk::TRACING_TARGET,
         "DB request",
         db.system = "postgresql",

--- a/tracing-opentelemetry-instrumentation-sdk/src/http/grpc_client.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/http/grpc_client.rs
@@ -10,7 +10,7 @@ use super::grpc_update_span_from_response;
 //TODO create similar but with tonic::Request<B> ?
 pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
     let (service, method) = extract_service_method(req.uri());
-    tracing::trace_span!(
+    tracing::info_span!(
         target: TRACING_TARGET,
         "GRPC request",
         http.user_agent = %user_agent(req),

--- a/tracing-opentelemetry-instrumentation-sdk/src/http/grpc_server.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/http/grpc_server.rs
@@ -8,7 +8,7 @@ use super::grpc_update_span_from_response;
 /// see [Semantic Conventions for gRPC | OpenTelemetry](https://opentelemetry.io/docs/specs/semconv/rpc/grpc/#grpc-status)
 pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
     let (service, method) = extract_service_method(req.uri());
-    tracing::trace_span!(
+    tracing::info_span!(
         target: TRACING_TARGET,
         "GRPC request",
         http.user_agent = %user_agent(req),

--- a/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
@@ -10,7 +10,7 @@ pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
     // [opentelemetry-specification/.../span-general.md](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md)
     // Can not use const or opentelemetry_semantic_conventions::trace::* for name of records
     let http_method = http_method(req.method());
-    tracing::trace_span!(
+    tracing::info_span!(
         target: TRACING_TARGET,
         "HTTP request",
         http.request.method = %http_method,


### PR DESCRIPTION
As the point where trace propogation is done, these spans are not implementation details but instead the very point of instrumentation.

Should one wish to disable them, setting otel::tracing to a level higher than info - e.g. error - will do so.