### PR TITLE
Fix broken /examples URLs

### DIFF
--- a/axum-tracing-opentelemetry/README.md
+++ b/axum-tracing-opentelemetry/README.md
@@ -12,7 +12,7 @@ Middlewares to integrate axum + tracing + opentelemetry.
 - Trace is attached into tracing'span
 - OpenTelemetry Span is created on close of the tracing's span (behavior from [tracing-opentelemetry])
 
-For examples, you can look at the [examples](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/examples/) folder.
+For examples, you can look at the [examples](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/tree/main/examples/) folder.
 
 ```txt
 //...

--- a/tonic-tracing-opentelemetry/README.md
+++ b/tonic-tracing-opentelemetry/README.md
@@ -13,7 +13,7 @@ Middlewares and tools to integrate tonic + tracing + opentelemetry for client an
 - Start a new trace if no trace is found in the incoming request
 - Trace is attached into tracing's span
 
-For examples, you can look at the [examples](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/examples/) folder.
+For examples, you can look at the [examples](https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/tree/main/examples/) folder.
 
 Extract of `client.rs`:
 


### PR DESCRIPTION
The existing links to the examples folder in the README files returns 404.