### PR TITLE
Add link to reqwest-client feature

### DIFF
--- a/init-tracing-opentelemetry/Cargo.toml
+++ b/init-tracing-opentelemetry/Cargo.toml
@@ -58,7 +58,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 
 [features]
 jaeger = ["dep:opentelemetry-jaeger-propagator"]
-otlp = ["opentelemetry-otlp/http-proto", "tracer"]
+otlp = ["opentelemetry-otlp/http-proto", "opentelemetry-otlp/reqwest-client", "tracer"]
 stdout = ["dep:opentelemetry-stdout", "tracer"]
 tracer = ["dep:opentelemetry-semantic-conventions"]
 xray = ["dep:opentelemetry-aws"]


### PR DESCRIPTION
The opentelmetry-otlp package by default loads the opentelemetry-http package in such a way that it does not have an actual http client available, which causes it to error `ExportFailed(NoHttpClient)` on initialization. I added in a link to the `opentelmetry-otlp` `reqwest-client` feature, which will in turn load the `reqwest` crate and link in the `opentelemetry-http` crate's `reqwest` feature.

I'm not 100% this is the best way to do it - the `opentelemetry-otlp` crate has a number of other features allowing for the http client to be activated in other ways. We might want to provide crate consumers more options in how to load it, but I'm not sure what that should look like. On the other hand, if the design intent for this crate is to provide a basic good-enough OpenTelemetry config for most use cases, and users with other requirements can do it manually, then it may be good enough.