### PR TITLE
Add a helper to the sdk to retrieve the span_id

### DIFF
--- a/tracing-opentelemetry-instrumentation-sdk/src/lib.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/lib.rs
@@ -130,6 +130,18 @@ pub fn find_trace_id(context: &Context) -> Option<String> {
     // };
 }
 
+#[inline]
+#[must_use]
+pub fn find_span_id(context: &Context) -> Option<String> {
+    use opentelemetry::trace::TraceContextExt;
+
+    let span = context.span();
+    let span_context = span.span_context();
+    span_context
+        .is_valid()
+        .then(|| span_context.span_id().to_string())
+}
+
 // pub(crate) fn set_otel_parent(parent_context: Context, span: &tracing::Span) {
 //     use opentelemetry::trace::TraceContextExt as _;
 //     use tracing_opentelemetry::OpenTelemetrySpanExt as _;


### PR DESCRIPTION
As the TraceContextExt trait cannot be pulled in to a consuming crate, add a helper to this crate to allow the span_id to be retrieved from a OpenTelemetry Context.