### PR TITLE
[Bugfix] Add tracing_level_info feature to tonic-tracing crate

### DIFF
--- a/tonic-tracing-opentelemetry/Cargo.toml
+++ b/tonic-tracing-opentelemetry/Cargo.toml
@@ -64,3 +64,8 @@ opentelemetry_sdk = { workspace = true, features = [
   "rt-tokio",
   "testing",
 ] }
+
+[features]
+default = []
+# to use level `info` instead of `trace` to create otel span
+tracing_level_info = []


### PR DESCRIPTION
Adding the feature to the tonic-tracing-opentelemetry crate as features are not visible across packages - https://doc.rust-lang.org/cargo/reference/features.html#feature-unification