### PR TITLE
Update otel libraries to 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+### Added
+
+### Changed
+
+- ⬆️ upgrade to opentelemetry 0.24 (and related dependencies)
+
+
+### Fixed
+
+
 ## [0.17.0] - 2024-02-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ rust-version = "1.73.0"
 
 [workspace.dependencies]
 http = "^1"
-opentelemetry = { version = "0.23", features = [
+opentelemetry = { version = "0.24", features = [
   "trace",
 ], default-features = false }
-opentelemetry_sdk = { version = "0.23", default-features = false, features = [
+opentelemetry_sdk = { version = "0.24.1", default-features = false, features = [
   "rt-tokio",
 ] }
 opentelemetry-aws = { version = "0.11", default-features = false }
@@ -35,12 +35,12 @@ opentelemetry-jaeger-propagator = { version = "0.2", default-features = false }
 opentelemetry-resource-detectors = { version = "0.2.0", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.15", default-features = false }
 opentelemetry-zipkin = { version = "0.21", default-features = false }
-opentelemetry-otlp = { version = "0.16", default-features = false }
+opentelemetry-otlp = { version = "0.17", default-features = false }
 opentelemetry-proto = { version = "0.6", default-features = false }
 opentelemetry-stdout = { version = "0.4" }
 tonic = { version = "0.11", default-features = false } #should be sync with opentelemetry-proto
 tracing = "0.1"
-tracing-opentelemetry = "0.24"
+tracing-opentelemetry = "0.25"
 
 [profile.dev.package.insta]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To collect and visualize trace on local, one of the simplest solution:
 # launch Jaeger with OpenTelemetry, Jaeger, Zipking,... mode.
 # see https://www.jaegertracing.io/docs/1.49/getting-started/#all-in-one
 
-# nerctl or docker or any container runner
+# nerdctl or docker or any container runner
 nerdctl run --rm --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT:9411 \
   -e COLLECTOR_OTLP_ENABLED:true \


### PR DESCRIPTION
Bumps the version of opentelemetry to use 0.24.

I've only tested the axum middleware which is working end to end