### PR TITLE
use native root tls certificates in tonic exporter

### DIFF
--- a/init-tracing-opentelemetry/src/otlp.rs
+++ b/init-tracing-opentelemetry/src/otlp.rs
@@ -39,7 +39,7 @@ where
         #[cfg(feature = "tls")]
         "grpc/tls" => opentelemetry_otlp::new_exporter()
             .tonic()
-            .with_tls_config(ClientTlsConfig::new())
+            .with_tls_config(ClientTlsConfig::new().with_native_roots())
             .with_endpoint(endpoint)
             .into(),
         _ => opentelemetry_otlp::new_exporter()


### PR DESCRIPTION
Starting from tonic 0.12, native TLS root certificates are no longer used by default by tonic exporter (more details here: https://github.com/open-telemetry/opentelemetry-rust/issues/2008#issuecomment-2292294188).
Calling `with_native_roots()` on `ClientTlsConfig` restores the previous behavior.