### PR TITLE
Add reqwest-rustls feature to otlp

### DIFF
--- a/init-tracing-opentelemetry/Cargo.toml
+++ b/init-tracing-opentelemetry/Cargo.toml
@@ -62,6 +62,7 @@ jaeger = ["dep:opentelemetry-jaeger-propagator"]
 otlp = [
   "opentelemetry-otlp/http-proto",
   "opentelemetry-otlp/reqwest-client",
+  "opentelemetry-otlp/reqwest-rustls",
   "tracer",
 ]
 stdout = ["dep:opentelemetry-stdout", "tracer"]


### PR DESCRIPTION
Our organization uses a https URL for our OpenTelemetry servers, and it turns out it won't connect to them at all without this feature enabled on the `opentelemetry-otlp` crate. 

Similarly to the previous one, we could do a feature for this, but given that it's kind of a headache to track the resulting errors back to needing to enable a TLS feature, it may be best to leave it on for everyone.