### PR TITLE
fix: Use guard pattern to allow consumers to ensure final trace is sent

### DIFF
--- a/axum-tracing-opentelemetry/README.md
+++ b/axum-tracing-opentelemetry/README.md
@@ -20,17 +20,15 @@ use axum_tracing_opentelemetry::opentelemetry_tracing_layer;
 
 #[tokio::main]
 async fn main() -> Result<(), axum::BoxError> {
-    // very opinionated init of tracing, look as is source to make your own
-    init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()?;
+    // very opinionated init of tracing, look at the source to make your own
+    let _guard = init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()?;
 
     let app = app();
     // run it
     let addr = &"0.0.0.0:3000".parse::<SocketAddr>()?;
     tracing::warn!("listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service())
-        //FIXME .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    axum::serve(listener, app.into_make_service()).await?;
     Ok(())
 }
 
@@ -42,11 +40,6 @@ fn app() -> Router {
         //start OpenTelemetry trace on incoming request
         .layer(OtelAxumLayer::default())
         .route("/health", get(health)) // request processed without span / trace
-}
-
-async fn shutdown_signal() {
-    //...
-    opentelemetry::global::shutdown_tracer_provider();
 }
 ```
 

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -13,7 +13,7 @@ pub mod generated {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // very opinionated init of tracing, look as is source to make your own
-    init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()
+    let _guard = init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()
         .expect("init subscribers");
 
     // let channel = Channel::from_static("http://[::1]:50051").connect().await?;
@@ -53,6 +53,5 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("RESPONSE={:?}", response);
     }
 
-    opentelemetry::global::shutdown_tracer_provider();
     Ok(())
 }

--- a/examples/load/src/main.rs
+++ b/examples/load/src/main.rs
@@ -7,7 +7,7 @@ use tracing_opentelemetry_instrumentation_sdk::otel_trace_span;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // very opinionated init of tracing, look as is source to make your own
-    init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()?;
+    let _guard = init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()?;
     let mut stats = memory_stats();
     if stats.is_none() {
         eprintln!("Couldn't get the current memory usage :(");

--- a/init-tracing-opentelemetry/README.md
+++ b/init-tracing-opentelemetry/README.md
@@ -12,7 +12,7 @@ use axum_tracing_opentelemetry::opentelemetry_tracing_layer;
 #[tokio::main]
 async fn main() -> Result<(), axum::BoxError> {
     // very opinionated init of tracing, look as is source to compose your own
-    init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()?;
+    let _guard = init_tracing_opentelemetry::tracing_subscriber_ext::init_subscribers()?;
 
     ...;
 
@@ -20,7 +20,7 @@ async fn main() -> Result<(), axum::BoxError> {
 }
 ```
 
-AND Call `opentelemetry::global::shutdown_tracer_provider();` on shutdown of the app to be sure to send the pending trace,...
+The `init_subscribers` function returns a `TracingGuard` instance. Following the guard pattern, this struct provides no functions but, when dropped, ensures that any pending traces are sent before it exits. The syntax `let _guard` is suggested to ensure that Rust does not drop the struct until the application exits.
 
 To configure opentelemetry tracer & tracing, you can use the functions from `init_tracing_opentelemetry::tracing_subscriber_ext`, but they are very opinionated (and WIP to make them more customizable and friendly), so we recommend making your composition, but look at the code (to avoid some issue) and share your feedback.
 

--- a/init-tracing-opentelemetry/src/tracing_subscriber_ext.rs
+++ b/init-tracing-opentelemetry/src/tracing_subscriber_ext.rs
@@ -92,6 +92,7 @@ where
     Ok((layer, TracingGuard { tracerprovider }))
 }
 
+#[must_use = "Recommend holding with 'let _guard = ' pattern to ensure final traces are sent to the server"]
 pub struct TracingGuard {
     tracerprovider: trace::TracerProvider,
 }


### PR DESCRIPTION
In discussion with the Rust OpenTelemetry crate maintainers, the `shutdown_tracer_provider` function intentionally no longer ensures that the final traces are sent to the OpenTelemetry server before the application exits. To perform this functionality, we now need to call `force_flush` on the TracerProvider instance.

Since the public API functions for the TracerProvider only return a trait object which does not have this function exposed, we need to keep an instance of the actual TracerProvider around. In order to make this simple for consumers of this crate, I have used the guard pattern here so that they do not need to worry about those details or pull in the crates that provide those types. An instance of the TracerProvider is kept in a private field of the TracingGuard struct, which is returned by the init functions. That struct impls `Drop` to call `force_flush` when the struct is dropped. As such, crate consumers only need to use the `let _guard =` syntax to ensure the guard is only dropped when the function actually exits. This also allows us to, in the future, include other provider flushes in the same pattern, such as for OpenTelemetry logs and metrics.

In addition, as the `Drop` impl only performs a `force_flush`, if any consumers of this crate update to a version with this and do not make any code changes, their code will continue to behave exactly the same - the guard struct will be dropped immediately, triggering the `force_flush`, but the provider will continue to operate. Their application will behave exactly as it did before with regard to sending traces. It only loses the behavior of ensuring the final traces are sent before application exit, but that wasn't working before this anyways.

Resolves #184 

