### PR TITLE
Implement tower::Service for OtelGrpcService

### DIFF
--- a/tonic-tracing-opentelemetry/src/middleware/client.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/client.rs
@@ -8,7 +8,7 @@ use std::{
     task::{Context, Poll},
 };
 use tonic::client::GrpcService;
-use tower::Layer;
+use tower::{Layer, Service};
 use tracing::Span;
 use tracing_opentelemetry_instrumentation_sdk::{find_context_from_tracing, http as otel_http};
 
@@ -34,7 +34,7 @@ pub struct OtelGrpcService<S> {
     inner: S,
 }
 
-impl<S, B, B2> GrpcService<B> for OtelGrpcService<S>
+impl<S, B, B2> Service<Request<B>> for OtelGrpcService<S>
 where
     S: GrpcService<B, ResponseBody = B2> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -43,7 +43,7 @@ where
     // B2: tonic::codegen::Body,
     B2: http_body::Body,
 {
-    type ResponseBody = B2;
+    type Response = Response<B2>;
     type Error = S::Error;
     type Future = ResponseFuture<S::Future>;
     // #[allow(clippy::type_complexity)]


### PR DESCRIPTION
Implementing `Service` gives you the `GrpcService` implementation for free, and it also comes with the benefits of the `Service` trait, such as being able to use interceptors:
```rs
struct MyInterceptor;

impl tonic::service::Interceptor for MyInterceptor {
    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
        Ok(request)
    }
}
```

```diff
# examples/grpc/src/client.rs

  let channel = ServiceBuilder::new().layer(OtelGrpcLayer).service(channel);

- let mut client = GreeterClient::new(channel);
+ let mut client = GreeterClient::with_interceptor(channel, MyInterceptor);
```

The above change currently fails to compile because `MyInterceptor` doesn't implement `Service` (which `InterceptedService` requires), only `GrpcService`.