### PR TITLE
fix: route in axum example

### DIFF
--- a/examples/axum-otlp/src/main.rs
+++ b/examples/axum-otlp/src/main.rs
@@ -28,7 +28,7 @@ fn app() -> Router {
     // build our application with a route
     Router::new()
         .route(
-            "/proxy/:service/*path",
+            "/proxy/{service}/{*path}",
             get(proxy_handler).post(proxy_handler),
         )
         .route("/", get(index)) // request processed inside span


### PR DESCRIPTION
From axum 0.8 release note:

> changing the path parameter syntax from /:single and /*many to
> /{single} and /{*many}
