### PR TITLE
feat: allow to provide log's "directives" via `init_subscribers_and_loglevel`

### DIFF
--- a/init-tracing-opentelemetry/src/error.rs
+++ b/init-tracing-opentelemetry/src/error.rs
@@ -8,4 +8,8 @@ pub enum Error {
 
     #[error(transparent)]
     TraceError(#[from] opentelemetry::trace::TraceError),
+
+    #[cfg(feature = "tracing_subscriber_ext")]
+    #[error(transparent)]
+    FilterParseError(#[from] tracing_subscriber::filter::ParseError),
 }


### PR DESCRIPTION
- so log's level filter could be defined by parameter (without need to override `RUST_LOG` env variable on caller side
- remove use of `std::env::set_var` (in the lib, and maybe on caller side) that becomes `unsafe` since rust 1.85