### PR TITLE
Must use blocking client now

### DIFF
--- a/init-tracing-opentelemetry/Cargo.toml
+++ b/init-tracing-opentelemetry/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 jaeger = ["dep:opentelemetry-jaeger-propagator"]
 otlp = [
   "opentelemetry-otlp/http-proto",
-  "opentelemetry-otlp/reqwest-client",
+  "opentelemetry-otlp/reqwest-blocking-client",
   "opentelemetry-otlp/reqwest-rustls",
   "tracer",
 ]


### PR DESCRIPTION
I was getting in my local and deployed testing:

```
thread 'OpenTelemetry.Traces.BatchProcessor' panicked at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/ops/function.rs:250:5:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

Checking some searches and other Github discussions, I found [this bug](https://github.com/open-telemetry/opentelemetry-rust/issues/2673) which linked [this doc section](https://github.com/open-telemetry/opentelemetry-rust/blob/main/docs/migration_0.28.md#async-runtime-requirements-removed). It seems only the blocking reqwest client is supported by otlp now. This seems to fix it on my local.