### PR TITLE
Fix the `tracing_level_info` feature in `tonic-tracing-opentelemetry`

### DIFF
--- a/tonic-tracing-opentelemetry/Cargo.toml
+++ b/tonic-tracing-opentelemetry/Cargo.toml
@@ -63,4 +63,6 @@ opentelemetry_sdk = { workspace = true, features = [
 [features]
 default = []
 # to use level `info` instead of `trace` to create otel span
-tracing_level_info = []
+tracing_level_info = [
+  "tracing-opentelemetry-instrumentation-sdk/tracing_level_info",
+]


### PR DESCRIPTION
Enabling `tracing_level_info` in `tonic-tracing-opentelemetry` currently does nothing because the feature is actually implemented in `tracing-opentelemetry-instrumentation-sdk`. Fix by making it enable the corresponding feature in the dependency.