### PR TITLE
fix: don't log a warning if span is disabled

### DIFF
--- a/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
+++ b/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
@@ -138,7 +138,7 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
         let req = req;
         let span = if self.filter.is_none_or(|f| f(req.uri().path())) {
             let route = http_route(&req);
@@ -162,7 +162,12 @@ where
                 span.record(CLIENT_ADDRESS, client_ip);
             }
             if let Err(error) = span.set_parent(otel_http::extract_context(req.headers())) {
-                tracing::warn!(?error, "can not set parent trace_id to span");
+                match error {
+                    SetParentError::LayerNotFound | SetParentError::AlreadyStarted => {
+                        tracing::warn!(?error, "can not set parent trace_id to span");
+                    }
+                    SetParentError::SpanDisabled => {}
+                }
             }
             span
         } else {

--- a/tonic-tracing-opentelemetry/src/middleware/client.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/client.rs
@@ -17,7 +17,7 @@ use tracing_opentelemetry_instrumentation_sdk::{find_context_from_tracing, http 
 /// - propagate `OpenTelemetry` context (`trace_id`,...) to server
 /// - create a Span for `OpenTelemetry` (and tracing) on call
 ///
-/// `OpenTelemetry` context are extracted frim tracing's span.
+/// `OpenTelemetry` context are extracted from tracing's span.
 #[derive(Default, Debug, Clone)]
 pub struct OtelGrpcLayer;
 

--- a/tonic-tracing-opentelemetry/src/middleware/server.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/server.rs
@@ -72,7 +72,7 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
         // This is necessary because tonic internally uses `tower::buffer::Buffer`.
         // See https://github.com/tower-rs/tower/issues/547#issuecomment-767629149
         // for details on why this is necessary
@@ -82,7 +82,12 @@ where
         let span = if self.filter.is_none_or(|f| f(req.uri().path())) {
             let span = otel_http::grpc_server::make_span_from_request(&req);
             if let Err(error) = span.set_parent(otel_http::extract_context(req.headers())) {
-                tracing::warn!(?error, "can not set parent trace_id to span");
+                match error {
+                    SetParentError::LayerNotFound | SetParentError::AlreadyStarted => {
+                        tracing::warn!(?error, "can not set parent trace_id to span");
+                    }
+                    SetParentError::SpanDisabled => {}
+                }
             }
             span
         } else {

--- a/tonic-tracing-opentelemetry/src/middleware/server.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/server.rs
@@ -17,7 +17,7 @@ pub type Filter = fn(&str) -> bool;
 /// - propagate `OpenTelemetry` context (`trace_id`, ...) to server
 /// - create a Span for `OpenTelemetry` (and tracing) on call
 ///
-/// `OpenTelemetry` context are extracted frim tracing's span.
+/// `OpenTelemetry` context are extracted from tracing's span.
 #[derive(Default, Debug, Clone)]
 pub struct OtelGrpcLayer {
     filter: Option<Filter>,


### PR DESCRIPTION
This has been logging lots of unactionable warnings, don't log in that
case.

See https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/310#issuecomment-4412540702

Also fixes a typo.