### PR TITLE
Fix type of `http.response.status_code` attribute

### DIFF
--- a/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
+++ b/tracing-opentelemetry-instrumentation-sdk/src/http/http_server.rs
@@ -37,7 +37,7 @@ pub fn make_span_from_request<B>(req: &http::Request<B>) -> tracing::Span {
 
 pub fn update_span_from_response<B>(span: &tracing::Span, response: &http::Response<B>) {
     let status = response.status();
-    span.record(HTTP_RESPONSE_STATUS_CODE, status.as_u16());
+    span.record(HTTP_RESPONSE_STATUS_CODE, i64::from(status.as_u16()));
 
     if status.is_server_error() {
         span.record(OTEL_STATUS_CODE, "ERROR");


### PR DESCRIPTION
`tracing` widens `u16` to `u64` when using it as an attribute (see [here](https://github.com/tokio-rs/tracing/blob/tracing-core-0.1.36/tracing-core/src/field.rs#L553)), but `tracing-opentelemetry` does not (and cannot) handle `u64` (see [here](https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.33.0/src/layer.rs#L512)), so it defaults to being recorded as a string. explicitly converting from `u16` to `i64` allows the attribute to be recorded properly by `tracing-opentelemetry`.

I have tested this change locally, and it correctly records the value in `opentelemetry` spans as an `i64`. I did not see any current tests where I could easily add a couple lines to assert this change, and I'm not sure how you'd want to test something like that.