### PR TITLE
Explore assertables macros for a couple of OTLP metric tests (feedback welcome)

### DIFF
--- a/fake-opentelemetry-collector/Cargo.toml
+++ b/fake-opentelemetry-collector/Cargo.toml
@@ -38,4 +38,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 assert2 = { workspace = true }
+assertables = "10"
 insta = { workspace = true }

--- a/fake-opentelemetry-collector/tests/demo_metrics.rs
+++ b/fake-opentelemetry-collector/tests/demo_metrics.rs
@@ -1,3 +1,4 @@
+use assertables::assert_some;
 use fake_opentelemetry_collector::{FakeCollectorServer, setup_meter_provider};
 use opentelemetry::{KeyValue, global};
 use std::time::Duration;
@@ -59,7 +60,7 @@ async fn demo_fake_meter_and_collector() {
     insta::assert_yaml_snapshot!(otel_metrics, {
         // Validate gauge metric
         "[0].metrics[0].name" => insta::dynamic_redaction(|value, _path| {
-            assert2::assert!(let Some(name) = value.as_str());
+            let name = assert_some!(value.as_str());
             assert_eq!(name, "test_gauge");
             name.to_string()
         }),
@@ -74,7 +75,7 @@ async fn demo_fake_meter_and_collector() {
             unit.to_string()
         }),
         "[0].metrics[0].data.Gauge.data_points[0].value.AsDouble" => insta::dynamic_redaction(|value, _path| {
-            assert2::assert!(let Some(val) = value.as_f64());
+            let val = assert_some!(value.as_f64());
             assert!((val - 123.456).abs() < 0.001);
             format!("{val}")
         }),
@@ -101,7 +102,7 @@ async fn demo_fake_meter_and_collector() {
             format!("{val}")
         }),
         "[0].metrics[1].data.Sum.is_monotonic" => insta::dynamic_redaction(|value, _path| {
-            assert2::assert!(let Some(monotonic) = value.as_bool());
+            let monotonic = assert_some!(value.as_bool());
             assert!(!monotonic);
             format!("{monotonic}")
         }),
@@ -187,7 +188,7 @@ async fn demo_fake_meter_and_collector() {
 
         // Validate attributes for all metrics
         "[].metrics[].data.**.attributes.foo" => insta::dynamic_redaction(|value, _path| {
-            assert2::assert!(let Some(attr_value) = value.as_str());
+            let attr_value = assert_some!(value.as_str());
             assert!(attr_value.contains("bar"));
             "\"Some(AnyValue { value: Some(StringValue(\\\"bar\\\")) })\""
         }),


### PR DESCRIPTION
Hi! I'm Joel, maintainer of [assertables](https://github.com/assertables/assertables-rust-crate), a Rust assertion-macro crate. This PR (both the code and this description) was put together by me together with an AI coding assistant (Claude Code) just to be up front.

I noticed `fake-opentelemetry-collector/tests/demo_metrics.rs` has a bunch of `insta::dynamic_redaction` closures that pull a typed value out of a `serde_json::Value` using a pattern like:

```rust
assert2::assert!(let Some(name) = value.as_str());
```

That's the shape of `assertables::assert_some!`. It checks that an expression is `Some(..)`, panics with a debug-style message showing the actual value if it isn't, and returns the unwrapped inner value, so you can bind it in one line instead of asserting and then re-reading the variable. 

For example see in that file:
- the gauge metric's `name`, its `AsDouble` value, 
- the up-down-counter's `is_monotonic` flag
- the `attributes.foo` string value

You could change them to `assert_some!`.

This PR is exploratory, because I'm seeking to improve `assertables` and seeking constructive feedback from developers who are use more kinds of asserts. Does this read better, worse, or just different? I'm happy to adjust, discuss, or just close this out. If it's easier for you to connect via email I'm  joel@joelparkerhenderson.com.
