### PR TITLE
fix: do not warn when request span is disabled

### DIFF
--- a/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
+++ b/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
@@ -138,7 +138,7 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
         let req = req;
         let span = if self.filter.is_none_or(|f| f(req.uri().path())) {
             let route = http_route(&req);
@@ -162,7 +162,12 @@ where
                 span.record(CLIENT_ADDRESS, client_ip);
             }
             if let Err(error) = span.set_parent(otel_http::extract_context(req.headers())) {
-                tracing::warn!(?error, "can not set parent trace_id to span");
+                match error {
+                    SetParentError::SpanDisabled => {}
+                    SetParentError::LayerNotFound | SetParentError::AlreadyStarted => {
+                        tracing::warn!(?error, "can not set parent trace_id to span");
+                    }
+                }
             }
             span
         } else {
@@ -283,5 +288,21 @@ mod tests {
         }
         let (tracing_events, otel_spans) = fake_env.collect_traces().await;
         assert_trace(name, tracing_events, otel_spans, is_trace_id_constant);
+    }
+
+    #[tokio::test]
+    async fn disabled_request_span_does_not_warn() {
+        let mut fake_env = FakeEnvironment::setup_with_filter("warn").await;
+        {
+            let mut svc = Router::new()
+                .route("/", get(|| async { StatusCode::OK }))
+                .layer(OtelAxumLayer::default());
+            let req = Request::new(Body::empty());
+            let _res = svc.call(req).await.unwrap();
+        }
+
+        let (tracing_events, otel_spans) = fake_env.collect_traces().await;
+        assert!(tracing_events.is_empty());
+        assert!(otel_spans.is_empty());
     }
 }

--- a/testing-tracing-opentelemetry/src/lib.rs
+++ b/testing-tracing-opentelemetry/src/lib.rs
@@ -93,6 +93,10 @@ pub struct FakeEnvironment {
 
 impl FakeEnvironment {
     pub async fn setup() -> Self {
+        Self::setup_with_filter("trace").await
+    }
+
+    pub async fn setup_with_filter(filter: &str) -> Self {
         //use axum::body::HttpBody as _;
         //use tower::{Service, ServiceExt};
         use tracing_subscriber::layer::SubscriberExt;
@@ -113,7 +117,7 @@ impl FakeEnvironment {
             .with_writer(make_writer)
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
         let subscriber = tracing_subscriber::registry()
-            .with(EnvFilter::try_new("trace").unwrap())
+            .with(EnvFilter::try_new(filter).unwrap())
             .with(fmt_layer)
             .with(otel_layer);
         let _subsciber_guard = subscriber.set_default();

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote_otel_spans.snap
@@ -13,7 +13,7 @@ expression: otel_spans
   attributes:
     busy_ns: ignore
     code.file.path: "Some(AnyValue { value: Some(StringValue(\"axum-tracing-opentelemetry/src/middleware/trace_extractor.rs\")) })"
-    code.line.number: "Some(AnyValue { value: Some(IntValue(257)) })"
+    code.line.number: "Some(AnyValue { value: Some(IntValue(262)) })"
     code.module.name: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"
     idle_ns: ignore
     target: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_otel_spans.snap
@@ -13,7 +13,7 @@ expression: otel_spans
   attributes:
     busy_ns: ignore
     code.file.path: "Some(AnyValue { value: Some(StringValue(\"axum-tracing-opentelemetry/src/middleware/trace_extractor.rs\")) })"
-    code.line.number: "Some(AnyValue { value: Some(IntValue(257)) })"
+    code.line.number: "Some(AnyValue { value: Some(IntValue(262)) })"
     code.module.name: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"
     idle_ns: ignore
     target: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"

--- a/tonic-tracing-opentelemetry/src/middleware/server.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/server.rs
@@ -72,7 +72,7 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
         // This is necessary because tonic internally uses `tower::buffer::Buffer`.
         // See https://github.com/tower-rs/tower/issues/547#issuecomment-767629149
         // for details on why this is necessary
@@ -82,7 +82,12 @@ where
         let span = if self.filter.is_none_or(|f| f(req.uri().path())) {
             let span = otel_http::grpc_server::make_span_from_request(&req);
             if let Err(error) = span.set_parent(otel_http::extract_context(req.headers())) {
-                tracing::warn!(?error, "can not set parent trace_id to span");
+                match error {
+                    SetParentError::SpanDisabled => {}
+                    SetParentError::LayerNotFound | SetParentError::AlreadyStarted => {
+                        tracing::warn!(?error, "can not set parent trace_id to span");
+                    }
+                }
             }
             span
         } else {
@@ -126,5 +131,28 @@ where
         let result = futures_util::ready!(this.inner.poll(cx));
         otel_http::grpc::update_span_from_response_or_error(this.span, &result);
         Poll::Ready(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use testing_tracing_opentelemetry::FakeEnvironment;
+    use tower::service_fn;
+
+    #[tokio::test]
+    async fn disabled_request_span_does_not_warn() {
+        let mut fake_env = FakeEnvironment::setup_with_filter("warn").await;
+        {
+            let inner = service_fn(|_req: Request<()>| async {
+                Ok::<_, std::io::Error>(Response::new(()))
+            });
+            let mut svc = OtelGrpcLayer::default().layer(inner);
+            let _res = svc.call(Request::new(())).await.unwrap();
+        }
+
+        let (tracing_events, otel_spans) = fake_env.collect_traces().await;
+        assert!(tracing_events.is_empty());
+        assert!(otel_spans.is_empty());
     }
 }


### PR DESCRIPTION
Request spans are created at `TRACE` by default, or `INFO` with the `tracing_level_info` feature. When a deployment uses a higher filter such as `RUST_LOG=warn`, those spans are intentionally disabled.

The middleware still calls `set_parent`, receives `SpanDisabled`, and emits a warning for every request. On a busy service, this creates substantial log noise and can obscure warnings that indicate actual tracing problems.

Ignore `SpanDisabled` while preserving warnings for `LayerNotFound` and `AlreadyStarted`. Includes regression tests for both the Axum and Tonic middleware.

References #310 and #338.