### PR TITLE
fix: preserve remote context when request span is disabled

### DIFF
--- a/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
+++ b/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs
@@ -34,6 +34,7 @@
 
 use axum::extract::{ConnectInfo, MatchedPath};
 use http::{Request, Response};
+use opentelemetry::Context as OtelContext;
 use opentelemetry_semantic_conventions::attribute::{CLIENT_ADDRESS, HTTP_ROUTE};
 use pin_project_lite::pin_project;
 use std::{
@@ -138,9 +139,9 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
         let req = req;
-        let span = if self.filter.is_none_or(|f| f(req.uri().path())) {
+        let (span, fallback_context) = if self.filter.is_none_or(|f| f(req.uri().path())) {
             let route = http_route(&req);
             let method = req.method();
             let client_ip = if self.try_extract_client_ip {
@@ -161,20 +162,28 @@ where
             if let Some(client_ip) = client_ip {
                 span.record(CLIENT_ADDRESS, client_ip);
             }
-            if let Err(error) = span.set_parent(otel_http::extract_context(req.headers())) {
-                tracing::warn!(?error, "can not set parent trace_id to span");
-            }
-            span
+            let extracted_context = otel_http::extract_context(req.headers());
+            let fallback_context = match span.set_parent(extracted_context.clone()) {
+                Ok(()) => None,
+                Err(SetParentError::SpanDisabled) => Some(extracted_context),
+                Err(error @ (SetParentError::LayerNotFound | SetParentError::AlreadyStarted)) => {
+                    tracing::warn!(?error, "can not set parent trace_id to span");
+                    None
+                }
+            };
+            (span, fallback_context)
         } else {
-            tracing::Span::none()
+            (tracing::Span::none(), None)
         };
         let future = {
+            let _context_guard = fallback_context.clone().map(OtelContext::attach);
             let _enter = span.enter();
             self.inner.call(req)
         };
         ResponseFuture {
             inner: future,
             span,
+            fallback_context,
         }
     }
 }
@@ -187,6 +196,7 @@ pin_project! {
         #[pin]
         pub(crate) inner: F,
         pub(crate) span: Span,
+        pub(crate) fallback_context: Option<OtelContext>,
         // pub(crate) start: Instant,
     }
 }
@@ -200,6 +210,10 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
+        let _context_guard = this
+            .fallback_context
+            .as_ref()
+            .map(|context| context.clone().attach());
         let _guard = this.span.enter();
         let result = futures_util::ready!(this.inner.poll(cx));
         otel_http::http_server::update_span_from_response_or_error(this.span, &result);
@@ -283,5 +297,37 @@ mod tests {
         }
         let (tracing_events, otel_spans) = fake_env.collect_traces().await;
         assert_trace(name, tracing_events, otel_spans, is_trace_id_constant);
+    }
+
+    #[tokio::test]
+    async fn disabled_request_span_preserves_remote_context() {
+        const TRACE_ID: &str = "b2611246a58fd7ea623d2264c5a1e226";
+        const PARENT_SPAN_ID: &str = "b2c9b811f2f424af";
+
+        let mut fake_env = FakeEnvironment::setup_with_filter("warn").await;
+        {
+            let mut svc = Router::new()
+                .route(
+                    "/",
+                    get(|| async {
+                        let span = tracing::warn_span!("enabled child span");
+                        let _guard = span.enter();
+                        StatusCode::OK
+                    }),
+                )
+                .layer(OtelAxumLayer::default());
+            let req = Request::builder()
+                .header("traceparent", format!("00-{TRACE_ID}-{PARENT_SPAN_ID}-01"))
+                .body(Body::empty())
+                .unwrap();
+            let _res = svc.call(req).await.unwrap();
+        }
+
+        let (tracing_events, otel_spans) = fake_env.collect_traces().await;
+        assert_eq!(tracing_events.len(), 2);
+        assert_eq!(otel_spans.len(), 1);
+        assert_eq!(otel_spans[0].name, "enabled child span");
+        assert_eq!(otel_spans[0].trace_id, TRACE_ID);
+        assert_eq!(otel_spans[0].parent_span_id, PARENT_SPAN_ID);
     }
 }

--- a/testing-tracing-opentelemetry/src/lib.rs
+++ b/testing-tracing-opentelemetry/src/lib.rs
@@ -93,6 +93,10 @@ pub struct FakeEnvironment {
 
 impl FakeEnvironment {
     pub async fn setup() -> Self {
+        Self::setup_with_filter("trace").await
+    }
+
+    pub async fn setup_with_filter(filter: &str) -> Self {
         //use axum::body::HttpBody as _;
         //use tower::{Service, ServiceExt};
         use tracing_subscriber::layer::SubscriberExt;
@@ -113,7 +117,7 @@ impl FakeEnvironment {
             .with_writer(make_writer)
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
         let subscriber = tracing_subscriber::registry()
-            .with(EnvFilter::try_new("trace").unwrap())
+            .with(EnvFilter::try_new(filter).unwrap())
             .with(fmt_layer)
             .with(otel_layer);
         let _subsciber_guard = subscriber.set_default();

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_for_remote_otel_spans.snap
@@ -13,7 +13,7 @@ expression: otel_spans
   attributes:
     busy_ns: ignore
     code.file.path: "Some(AnyValue { value: Some(StringValue(\"axum-tracing-opentelemetry/src/middleware/trace_extractor.rs\")) })"
-    code.line.number: "Some(AnyValue { value: Some(IntValue(257)) })"
+    code.line.number: "Some(AnyValue { value: Some(IntValue(271)) })"
     code.module.name: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"
     idle_ns: ignore
     target: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"

--- a/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_otel_spans.snap
+++ b/testing-tracing-opentelemetry/src/snapshots/testing_tracing_opentelemetry__trace_id_in_child_span_otel_spans.snap
@@ -13,7 +13,7 @@ expression: otel_spans
   attributes:
     busy_ns: ignore
     code.file.path: "Some(AnyValue { value: Some(StringValue(\"axum-tracing-opentelemetry/src/middleware/trace_extractor.rs\")) })"
-    code.line.number: "Some(AnyValue { value: Some(IntValue(257)) })"
+    code.line.number: "Some(AnyValue { value: Some(IntValue(271)) })"
     code.module.name: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"
     idle_ns: ignore
     target: "Some(AnyValue { value: Some(StringValue(\"axum_tracing_opentelemetry::middleware::trace_extractor::tests\")) })"

--- a/tonic-tracing-opentelemetry/src/middleware/server.rs
+++ b/tonic-tracing-opentelemetry/src/middleware/server.rs
@@ -1,5 +1,6 @@
 //! code based on [tonic/examples/src/tower/client.rs at master · hyperium/tonic · GitHub](https://github.com/hyperium/tonic/blob/master/examples/src/tower/client.rs)
 use http::{Request, Response};
+use opentelemetry::Context as OtelContext;
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
@@ -72,29 +73,37 @@ where
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
         // This is necessary because tonic internally uses `tower::buffer::Buffer`.
         // See https://github.com/tower-rs/tower/issues/547#issuecomment-767629149
         // for details on why this is necessary
         // let clone = self.inner.clone();
         // let mut inner = std::mem::replace(&mut self.inner, clone);
         let req = req;
-        let span = if self.filter.is_none_or(|f| f(req.uri().path())) {
+        let (span, fallback_context) = if self.filter.is_none_or(|f| f(req.uri().path())) {
             let span = otel_http::grpc_server::make_span_from_request(&req);
-            if let Err(error) = span.set_parent(otel_http::extract_context(req.headers())) {
-                tracing::warn!(?error, "can not set parent trace_id to span");
-            }
-            span
+            let extracted_context = otel_http::extract_context(req.headers());
+            let fallback_context = match span.set_parent(extracted_context.clone()) {
+                Ok(()) => None,
+                Err(SetParentError::SpanDisabled) => Some(extracted_context),
+                Err(error @ (SetParentError::LayerNotFound | SetParentError::AlreadyStarted)) => {
+                    tracing::warn!(?error, "can not set parent trace_id to span");
+                    None
+                }
+            };
+            (span, fallback_context)
         } else {
-            tracing::Span::none()
+            (tracing::Span::none(), None)
         };
         let future = {
+            let _context_guard = fallback_context.clone().map(OtelContext::attach);
             let _enter = span.enter();
             self.inner.call(req)
         };
         ResponseFuture {
             inner: future,
             span,
+            fallback_context,
         }
     }
 }
@@ -107,6 +116,7 @@ pin_project! {
         #[pin]
         pub(crate) inner: F,
         pub(crate) span: Span,
+        pub(crate) fallback_context: Option<OtelContext>,
         // pub(crate) start: Instant,
     }
 }
@@ -122,9 +132,48 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
+        let _context_guard = this
+            .fallback_context
+            .as_ref()
+            .map(|context| context.clone().attach());
         let _guard = this.span.enter();
         let result = futures_util::ready!(this.inner.poll(cx));
         otel_http::grpc::update_span_from_response_or_error(this.span, &result);
         Poll::Ready(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use testing_tracing_opentelemetry::FakeEnvironment;
+    use tower::service_fn;
+
+    #[tokio::test]
+    async fn disabled_request_span_preserves_remote_context() {
+        const TRACE_ID: &str = "b2611246a58fd7ea623d2264c5a1e226";
+        const PARENT_SPAN_ID: &str = "b2c9b811f2f424af";
+
+        let mut fake_env = FakeEnvironment::setup_with_filter("warn").await;
+        {
+            let inner = service_fn(|_req: Request<()>| async {
+                let span = tracing::warn_span!("enabled child span");
+                let _guard = span.enter();
+                Ok::<_, std::io::Error>(Response::new(()))
+            });
+            let mut svc = OtelGrpcLayer::default().layer(inner);
+            let req = Request::builder()
+                .header("traceparent", format!("00-{TRACE_ID}-{PARENT_SPAN_ID}-01"))
+                .body(())
+                .unwrap();
+            let _res = svc.call(req).await.unwrap();
+        }
+
+        let (tracing_events, otel_spans) = fake_env.collect_traces().await;
+        assert_eq!(tracing_events.len(), 2);
+        assert_eq!(otel_spans.len(), 1);
+        assert_eq!(otel_spans[0].name, "enabled child span");
+        assert_eq!(otel_spans[0].trace_id, TRACE_ID);
+        assert_eq!(otel_spans[0].parent_span_id, PARENT_SPAN_ID);
     }
 }


### PR DESCRIPTION
`OtelAxumLayer` and `OtelGrpcLayer` set the extracted request context on a `tracing` span. When an `EnvFilter` disables that span, `set_parent` returns `SpanDisabled`. Ignoring the error removes the warning but also loses the incoming trace context, while enabling the request span solely for propagation creates additional spans.

This changes the middleware to retain the extracted OpenTelemetry context when `SpanDisabled` occurs and attach it while the inner service is created and polled. Child spans can then inherit the remote trace context without exporting the disabled request span. Other `set_parent` errors still warn.

The regression tests use a valid `traceparent` with the request span filtered out and verify that:

- only the enabled child span is exported;
- it keeps the incoming trace ID and parent span ID;
- no warning is emitted.

This applies the same behavior to the Axum and Tonic server middleware.

This is a follow-up to #338 and #359, adding context preservation rather than only suppressing `SpanDisabled`.

Refs #148.
Refs #310.